### PR TITLE
removes unnecessary pay endpoint string in createSignature

### DIFF
--- a/src/lib/transactions/merchant-transactions.routes.ts
+++ b/src/lib/transactions/merchant-transactions.routes.ts
@@ -101,7 +101,6 @@ export class MerchantApiTransactionsRoutes {
   public async refund(transactionId: string): Promise<IMerchantPayTransactionResponse> {
     const signature = MerchantHash.createSignature(
       "POST",
-      `${this.signatureBaseURI}/${transactionId}/pay`,
       `${this.signatureBaseURI}/${transactionId}/refund`,
       JSON.stringify({}),
       this.config.secretKey


### PR DESCRIPTION
Previous [PR](https://github.com/Ex-Nihilo-Ltd/ArkPay-merchant-api-sdk/pull/11/files) had both pay and refund transaction endpoint as a parameters for createSignature method. This takes care of it now.